### PR TITLE
adding 72 hour claimValidityPeriod

### DIFF
--- a/contracts/ClaimsManager.sol
+++ b/contracts/ClaimsManager.sol
@@ -144,8 +144,8 @@ contract ClaimsManager is
         address claimant,
         address beneficiary,
         uint256 coverageAmount,
-        uint256 startTime,
-        uint256 claimValidityPeriodEndTime,
+        uint256 claimsAllowedFrom,
+        uint256 claimsAllowedUntil,
         string calldata policy
     ) external override returns (bytes32 policyHash) {
         require(
@@ -155,9 +155,9 @@ contract ClaimsManager is
         require(claimant != address(0), "Claimant address zero");
         require(beneficiary != address(0), "Beneficiary address zero");
         require(coverageAmount != 0, "Coverage amount zero");
-        require(startTime != 0, "Start time zero");
+        require(claimsAllowedFrom != 0, "Start time zero");
         require(
-            claimValidityPeriodEndTime > startTime,
+            claimsAllowedUntil > claimsAllowedFrom,
             "Start not earlier than end"
         );
         require(bytes(policy).length != 0, "Policy address empty");
@@ -166,8 +166,8 @@ contract ClaimsManager is
                 claimant,
                 beneficiary,
                 coverageAmount,
-                startTime,
-                claimValidityPeriodEndTime,
+                claimsAllowedFrom,
+                claimsAllowedUntil,
                 policy
             )
         );
@@ -177,8 +177,8 @@ contract ClaimsManager is
             claimant,
             policyHash,
             coverageAmount,
-            startTime,
-            claimValidityPeriodEndTime,
+            claimsAllowedFrom,
+            claimsAllowedUntil,
             policy,
             msg.sender
         );
@@ -187,8 +187,8 @@ contract ClaimsManager is
     function createClaim(
         address beneficiary,
         uint256 coverageAmount,
-        uint256 startTime,
-        uint256 claimValidityPeriodEndTime,
+        uint256 claimsAllowedFrom,
+        uint256 claimsAllowedUntil,
         string calldata policy,
         uint256 claimAmount,
         string calldata evidence
@@ -198,18 +198,18 @@ contract ClaimsManager is
                 msg.sender,
                 beneficiary,
                 coverageAmount,
-                startTime,
-                claimValidityPeriodEndTime,
+                claimsAllowedFrom,
+                claimsAllowedUntil,
                 policy
             )
         );
         require(policyWithHashExists[policyHash], "Policy does not exist");
         require(claimAmount != 0, "Claim amount zero");
         require(bytes(evidence).length != 0, "Evidence address empty");
-        require(block.timestamp >= startTime, "Policy not active yet");
+        require(block.timestamp >= claimsAllowedFrom, "Claims not allowed yet");
         require(
-            block.timestamp <= claimValidityPeriodEndTime,
-            "Claim validity period expired"
+            block.timestamp <= claimsAllowedUntil,
+            "Claims not allowed anymore"
         );
         require(claimAmount <= coverageAmount, "Claim larger than coverage");
         claimIndex = claimCount++;
@@ -227,8 +227,8 @@ contract ClaimsManager is
             policyHash,
             beneficiary,
             coverageAmount,
-            startTime,
-            claimValidityPeriodEndTime,
+            claimsAllowedFrom,
+            claimsAllowedUntil,
             policy,
             claimAmount,
             evidence,

--- a/contracts/ClaimsManager.sol
+++ b/contracts/ClaimsManager.sol
@@ -169,6 +169,7 @@ contract ClaimsManager is
         require(startTime != 0, "Start time zero");
         require(endTime > startTime, "Start not earlier than end");
         require(bytes(policy).length != 0, "Policy address empty");
+        endTime += claimValidityPeriod;
         policyHash = keccak256(
             abi.encodePacked(
                 claimant,
@@ -201,6 +202,7 @@ contract ClaimsManager is
         uint256 claimAmount,
         string calldata evidence
     ) external override returns (uint256 claimIndex) {
+        endTime += claimValidityPeriod;
         bytes32 policyHash = keccak256(
             abi.encodePacked(
                 msg.sender,
@@ -215,10 +217,7 @@ contract ClaimsManager is
         require(claimAmount != 0, "Claim amount zero");
         require(bytes(evidence).length != 0, "Evidence address empty");
         require(block.timestamp >= startTime, "Policy not active yet");
-        require(
-            block.timestamp <= endTime + claimValidityPeriod,
-            "Claim validity period expired"
-        );
+        require(block.timestamp <= endTime, "Claim validity period expired");
         require(claimAmount <= coverageAmount, "Claim larger than coverage");
         claimIndex = claimCount++;
         claims[claimIndex] = Claim({

--- a/contracts/ClaimsManager.sol
+++ b/contracts/ClaimsManager.sol
@@ -35,7 +35,6 @@ contract ClaimsManager is
     address public override api3Pool;
     uint256 public override mediatorResponsePeriod;
     uint256 public override claimantResponsePeriod;
-    uint256 public override claimValidityPeriod;
     mapping(address => uint256) public override arbitratorToResponsePeriod;
     mapping(address => Checkpoint[])
         public
@@ -68,8 +67,7 @@ contract ClaimsManager is
         address _manager,
         address _api3Pool,
         uint256 _mediatorResponsePeriod,
-        uint256 _claimantResponsePeriod,
-        uint256 _claimValidityPeriod
+        uint256 _claimantResponsePeriod
     )
         AccessControlRegistryAdminnedWithManager(
             _accessControlRegistry,
@@ -92,7 +90,6 @@ contract ClaimsManager is
         _setApi3Pool(_api3Pool);
         _setMediatorResponsePeriod(_mediatorResponsePeriod);
         _setClaimantResponsePeriod(_claimantResponsePeriod);
-        _setClaimValidityPeriod(_claimValidityPeriod);
     }
 
     function setApi3Pool(address _api3Pool) external override {
@@ -121,14 +118,6 @@ contract ClaimsManager is
         uint256 arbitratorResponsePeriod
     ) external override onlyManagerOrAdmin {
         _setArbitratorResponsePeriod(arbitrator, arbitratorResponsePeriod);
-    }
-
-    function setClaimValidityPeriod(uint256 _claimValidityPeriod)
-        external
-        override
-    {
-        require(manager == msg.sender, "Sender not manager");
-        _setClaimValidityPeriod(_claimValidityPeriod);
     }
 
     // Allows setting a quota that is currently exceeded
@@ -561,11 +550,6 @@ contract ClaimsManager is
             arbitratorResponsePeriod,
             msg.sender
         );
-    }
-
-    function _setClaimValidityPeriod(uint256 _claimValidityPeriod) internal {
-        claimValidityPeriod = _claimValidityPeriod;
-        emit SetClaimValidityPeriod(_claimValidityPeriod);
     }
 
     function updateQuotaUsage(address account, uint256 amount) private {

--- a/contracts/ClaimsManager.sol
+++ b/contracts/ClaimsManager.sol
@@ -35,7 +35,7 @@ contract ClaimsManager is
     address public override api3Pool;
     uint256 public override mediatorResponsePeriod;
     uint256 public override claimantResponsePeriod;
-    uint256 public override claimValidityPeriod = 259200;
+    uint256 public override claimValidityPeriod;
     mapping(address => uint256) public override arbitratorToResponsePeriod;
     mapping(address => Checkpoint[])
         public
@@ -68,7 +68,8 @@ contract ClaimsManager is
         address _manager,
         address _api3Pool,
         uint256 _mediatorResponsePeriod,
-        uint256 _claimantResponsePeriod
+        uint256 _claimantResponsePeriod,
+        uint256 _claimValidityPeriod
     )
         AccessControlRegistryAdminnedWithManager(
             _accessControlRegistry,
@@ -91,6 +92,7 @@ contract ClaimsManager is
         _setApi3Pool(_api3Pool);
         _setMediatorResponsePeriod(_mediatorResponsePeriod);
         _setClaimantResponsePeriod(_claimantResponsePeriod);
+        _setClaimValidityPeriod(_claimValidityPeriod);
     }
 
     function setApi3Pool(address _api3Pool) external override {

--- a/contracts/ClaimsManager.sol
+++ b/contracts/ClaimsManager.sol
@@ -156,7 +156,7 @@ contract ClaimsManager is
         address beneficiary,
         uint256 coverageAmount,
         uint256 startTime,
-        uint256 endTime,
+        uint256 claimValidityPeriodEndTime,
         string calldata policy
     ) external override returns (bytes32 policyHash) {
         require(
@@ -167,16 +167,18 @@ contract ClaimsManager is
         require(beneficiary != address(0), "Beneficiary address zero");
         require(coverageAmount != 0, "Coverage amount zero");
         require(startTime != 0, "Start time zero");
-        require(endTime > startTime, "Start not earlier than end");
+        require(
+            claimValidityPeriodEndTime > startTime,
+            "Start not earlier than end"
+        );
         require(bytes(policy).length != 0, "Policy address empty");
-        endTime += claimValidityPeriod;
         policyHash = keccak256(
             abi.encodePacked(
                 claimant,
                 beneficiary,
                 coverageAmount,
                 startTime,
-                endTime,
+                claimValidityPeriodEndTime,
                 policy
             )
         );
@@ -187,7 +189,7 @@ contract ClaimsManager is
             policyHash,
             coverageAmount,
             startTime,
-            endTime,
+            claimValidityPeriodEndTime,
             policy,
             msg.sender
         );
@@ -197,19 +199,18 @@ contract ClaimsManager is
         address beneficiary,
         uint256 coverageAmount,
         uint256 startTime,
-        uint256 endTime,
+        uint256 claimValidityPeriodEndTime,
         string calldata policy,
         uint256 claimAmount,
         string calldata evidence
     ) external override returns (uint256 claimIndex) {
-        endTime += claimValidityPeriod;
         bytes32 policyHash = keccak256(
             abi.encodePacked(
                 msg.sender,
                 beneficiary,
                 coverageAmount,
                 startTime,
-                endTime,
+                claimValidityPeriodEndTime,
                 policy
             )
         );
@@ -217,7 +218,10 @@ contract ClaimsManager is
         require(claimAmount != 0, "Claim amount zero");
         require(bytes(evidence).length != 0, "Evidence address empty");
         require(block.timestamp >= startTime, "Policy not active yet");
-        require(block.timestamp <= endTime, "Claim validity period expired");
+        require(
+            block.timestamp <= claimValidityPeriodEndTime,
+            "Claim validity period expired"
+        );
         require(claimAmount <= coverageAmount, "Claim larger than coverage");
         claimIndex = claimCount++;
         claims[claimIndex] = Claim({
@@ -235,7 +239,7 @@ contract ClaimsManager is
             beneficiary,
             coverageAmount,
             startTime,
-            endTime,
+            claimValidityPeriodEndTime,
             policy,
             claimAmount,
             evidence,

--- a/contracts/interfaces/IClaimsManager.sol
+++ b/contracts/interfaces/IClaimsManager.sol
@@ -35,6 +35,8 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address sender
     );
 
+    event SetClaimValidityPeriod(uint256 claimValidityPeriod);
+
     event SetQuota(
         address indexed account,
         uint256 period,
@@ -50,7 +52,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         bytes32 indexed policyHash,
         uint256 coverageAmount,
         uint256 startTime,
-        uint256 endTime,
+        uint256 claimValidityPeriodEndTime,
         string policy,
         address sender
     );
@@ -62,7 +64,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address beneficiary,
         uint256 coverageAmount,
         uint256 startTime,
-        uint256 endTime,
+        uint256 claimValidityPeriodEndTime,
         string policy,
         uint256 claimAmount,
         string evidence,
@@ -133,6 +135,8 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         uint256 arbitratorResponsePeriod
     ) external;
 
+    function setClaimValidityPeriod(uint256 _claimValidityPeriod) external;
+
     function setQuota(
         address account,
         uint256 period,
@@ -146,7 +150,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address beneficiary,
         uint256 coverageAmount,
         uint256 startTime,
-        uint256 endTime,
+        uint256 claimValidityPeriodEndTime,
         string calldata policy
     ) external returns (bytes32 policyHash);
 
@@ -154,7 +158,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address beneficiary,
         uint256 coverageAmount,
         uint256 startTime,
-        uint256 endTime,
+        uint256 claimValidityPeriodEndTime,
         string calldata policy,
         uint256 claimAmount,
         string calldata evidence

--- a/contracts/interfaces/IClaimsManager.sol
+++ b/contracts/interfaces/IClaimsManager.sol
@@ -35,8 +35,6 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address sender
     );
 
-    event SetClaimValidityPeriod(uint256 claimValidityPeriod);
-
     event SetQuota(
         address indexed account,
         uint256 period,
@@ -134,8 +132,6 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address arbitrator,
         uint256 arbitratorResponsePeriod
     ) external;
-
-    function setClaimValidityPeriod(uint256 _claimValidityPeriod) external;
 
     function setQuota(
         address account,

--- a/contracts/interfaces/IClaimsManager.sol
+++ b/contracts/interfaces/IClaimsManager.sol
@@ -49,8 +49,8 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address indexed claimant,
         bytes32 indexed policyHash,
         uint256 coverageAmount,
-        uint256 startTime,
-        uint256 claimValidityPeriodEndTime,
+        uint256 claimsAllowedFrom,
+        uint256 claimsAllowedUntil,
         string policy,
         address sender
     );
@@ -61,8 +61,8 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         bytes32 indexed policyHash,
         address beneficiary,
         uint256 coverageAmount,
-        uint256 startTime,
-        uint256 claimValidityPeriodEndTime,
+        uint256 claimsAllowedFrom,
+        uint256 claimsAllowedUntil,
         string policy,
         uint256 claimAmount,
         string evidence,
@@ -145,16 +145,16 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address claimant,
         address beneficiary,
         uint256 coverageAmount,
-        uint256 startTime,
-        uint256 claimValidityPeriodEndTime,
+        uint256 claimsAllowedFrom,
+        uint256 claimsAllowedUntil,
         string calldata policy
     ) external returns (bytes32 policyHash);
 
     function createClaim(
         address beneficiary,
         uint256 coverageAmount,
-        uint256 startTime,
-        uint256 claimValidityPeriodEndTime,
+        uint256 claimsAllowedFrom,
+        uint256 claimsAllowedUntil,
         string calldata policy,
         uint256 claimAmount,
         string calldata evidence


### PR DESCRIPTION
Per Issue #2 and the service coverage T&Cs I've added a claim validity period enabling creation of a claim 72 hours (259200 seconds) after expiry of the policy, which is governable by manager.

New function and event should be added to IClaimsManager.sol as well if merged.