### PR TITLE
Policy upgrade

### DIFF
--- a/contracts/interfaces/IClaimsManager.sol
+++ b/contracts/interfaces/IClaimsManager.sol
@@ -58,6 +58,18 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address sender
     );
 
+    event UpgradedPolicy(
+        address beneficiary,
+        address indexed claimant,
+        bytes32 indexed policyHash,
+        uint256 coverageAmountInUsd,
+        uint256 claimsAllowedFrom,
+        uint256 claimsAllowedUntil,
+        string policy,
+        string metadata,
+        address sender
+    );
+
     event CreatedClaim(
         uint256 indexed claimIndex,
         address indexed claimant,

--- a/contracts/interfaces/IClaimsManager.sol
+++ b/contracts/interfaces/IClaimsManager.sol
@@ -214,10 +214,10 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         view
         returns (uint32 period, uint224 amountInApi3);
 
-    function policyHashToRemainingCoverageAmountInUsd(bytes32 policyHash)
+    function policyHashToState(bytes32 policyHash)
         external
         view
-        returns (uint256);
+        returns (uint32 claimsAllowedUntil, uint224 coverageAmountInUsd);
 
     function claimCount() external view returns (uint256);
 

--- a/contracts/interfaces/IClaimsManager.sol
+++ b/contracts/interfaces/IClaimsManager.sol
@@ -63,9 +63,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address indexed claimant,
         bytes32 indexed policyHash,
         address beneficiary,
-        uint256 coverageAmountInUsd,
         uint256 claimsAllowedFrom,
-        uint256 claimsAllowedUntil,
         string policy,
         uint256 claimAmountInUsd,
         string evidence,
@@ -159,9 +157,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
 
     function createClaim(
         address beneficiary,
-        uint256 coverageAmountInUsd,
         uint256 claimsAllowedFrom,
-        uint256 claimsAllowedUntil,
         string calldata policy,
         uint256 claimAmountInUsd,
         string calldata evidence


### PR DESCRIPTION
Closes https://github.com/api3dao/claims-manager/issues/28
Created [a separate issue](https://github.com/api3dao/claims-manager/issues/39) to track uint224/uint32 usage consistency

Policies keep the same policy hash after the upgrade so that when you upgrade your policy, your existing claims don't get interrupted. The policy admins are not authorized to downgrade/delete policies.