### PR TITLE
Hashify claims

### DIFF
--- a/contracts/ClaimsManager.sol
+++ b/contracts/ClaimsManager.sol
@@ -325,6 +325,10 @@ contract ClaimsManager is
                 evidence
             )
         );
+        require(
+            claimHashToState[claimHash].updateTime == 0,
+            "Claim already exists"
+        );
         claimHashToState[claimHash] = ClaimState({
             status: ClaimStatus.ClaimCreated,
             updateTime: uint32(block.timestamp),

--- a/contracts/ClaimsManager.sol
+++ b/contracts/ClaimsManager.sol
@@ -359,7 +359,7 @@ contract ClaimsManager is
         bytes32 claimHash = keccak256(
             abi.encodePacked(
                 policyHash,
-                msg.sender,
+                claimant,
                 beneficiary,
                 claimAmountInUsd,
                 evidence
@@ -406,7 +406,7 @@ contract ClaimsManager is
         bytes32 claimHash = keccak256(
             abi.encodePacked(
                 policyHash,
-                msg.sender,
+                claimant,
                 beneficiary,
                 claimAmountInUsd,
                 evidence
@@ -493,7 +493,7 @@ contract ClaimsManager is
         bytes32 claimHash = keccak256(
             abi.encodePacked(
                 policyHash,
-                msg.sender,
+                claimant,
                 beneficiary,
                 claimAmountInUsd,
                 evidence
@@ -543,7 +543,7 @@ contract ClaimsManager is
         bytes32 claimHash = keccak256(
             abi.encodePacked(
                 policyHash,
-                msg.sender,
+                claimant,
                 beneficiary,
                 claimAmountInUsd,
                 evidence

--- a/contracts/arbitrators/KlerosLiquidProxy.sol
+++ b/contracts/arbitrators/KlerosLiquidProxy.sol
@@ -52,22 +52,7 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
         uint256 claimAmountInUsd,
         string calldata evidence
     ) external payable override {
-        (, , bytes27 claimHash) = claimsManager.claims(claimIndex);
-        require(
-            claimHash ==
-                bytes27(
-                    keccak256(
-                        abi.encodePacked(
-                            policyHash,
-                            claimant,
-                            beneficiary,
-                            claimAmountInUsd,
-                            evidence
-                        )
-                    )
-                ),
-            "No such claim"
-        );
+        // claimsManager.createDispute() will validate the arguments so we don't need to
         require(msg.sender == claimant, "Sender not claimant");
         require(
             claimIndexToDisputeId[claimIndex] == 0,

--- a/contracts/arbitrators/KlerosLiquidProxy.sol
+++ b/contracts/arbitrators/KlerosLiquidProxy.sol
@@ -7,7 +7,6 @@ import "./interfaces/IKlerosLiquid.sol";
 
 contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
     struct ClaimDetails {
-        uint256 claimIndex;
         bytes32 policyHash;
         address claimant;
         address beneficiary;
@@ -23,14 +22,9 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
 
     uint256 private constant META_EVIDENCE_ID = 0;
 
-    mapping(uint256 => uint256) public override claimIndexToDisputeId;
+    mapping(bytes32 => uint256) public override claimHashToDisputeId;
 
     mapping(uint256 => ClaimDetails) public override disputeIdToClaimDetails;
-
-    modifier onlyDisputedClaim(uint256 claimIndex) {
-        require(claimIndexToDisputeId[claimIndex] != 0, "Invalid claim index");
-        _;
-    }
 
     constructor(
         address _claimsManager,
@@ -45,7 +39,6 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
     }
 
     function createDispute(
-        uint256 claimIndex,
         bytes32 policyHash,
         address claimant,
         address beneficiary,
@@ -54,8 +47,17 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
     ) external payable override {
         // claimsManager.createDispute() will validate the arguments so we don't need to
         require(msg.sender == claimant, "Sender not claimant");
+        bytes32 claimHash = keccak256(
+            abi.encodePacked(
+                policyHash,
+                msg.sender,
+                beneficiary,
+                claimAmountInUsd,
+                evidence
+            )
+        );
         require(
-            claimIndexToDisputeId[claimIndex] == 0,
+            claimHashToDisputeId[claimHash] == 0,
             "Dispute already created"
         );
         uint256 disputeId = klerosArbitrator.createDispute{value: msg.value}(
@@ -63,19 +65,22 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
             klerosArbitratorExtraData
         );
         disputeIdToClaimDetails[disputeId] = ClaimDetails({
-            claimIndex: claimIndex,
             policyHash: policyHash,
             claimant: claimant,
             beneficiary: beneficiary,
             amountInUsd: claimAmountInUsd,
             evidence: evidence
         });
-        claimIndexToDisputeId[claimIndex] = disputeId;
-        emit CreatedDispute(claimIndex, claimant, disputeId);
-        emit Dispute(klerosArbitrator, disputeId, META_EVIDENCE_ID, claimIndex);
-        emit Evidence(klerosArbitrator, claimIndex, claimant, evidence);
+        claimHashToDisputeId[claimHash] = disputeId;
+        emit CreatedDispute(claimHash, claimant, disputeId);
+        emit Dispute(
+            klerosArbitrator,
+            disputeId,
+            META_EVIDENCE_ID,
+            uint256(claimHash)
+        );
+        emit Evidence(klerosArbitrator, uint256(claimHash), claimant, evidence);
         claimsManager.createDispute(
-            claimIndex,
             policyHash,
             claimant,
             beneficiary,
@@ -85,45 +90,45 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
     }
 
     function submitEvidenceToKlerosArbitrator(
-        uint256 claimIndex,
+        bytes32 claimHash,
         string calldata evidence
-    ) external override onlyDisputedClaim(claimIndex) {
+    ) external override {
+        require(claimHashToDisputeId[claimHash] != 0, "Invalid claim");
         require(
             claimsManager.isManagerOrMediator(msg.sender),
             "Sender cannot mediate"
         );
         emit SubmittedEvidenceToKlerosArbitrator(
-            claimIndex,
+            claimHash,
             msg.sender,
             evidence
         );
-        emit Evidence(klerosArbitrator, claimIndex, msg.sender, evidence);
+        emit Evidence(
+            klerosArbitrator,
+            uint256(claimHash),
+            msg.sender,
+            evidence
+        );
     }
 
     function appealKlerosArbitratorRuling(
-        uint256 claimIndex,
         bytes32 policyHash,
         address claimant,
         address beneficiary,
         uint256 claimAmountInUsd,
         string calldata evidence
-    ) external payable override onlyDisputedClaim(claimIndex) {
-        (, , bytes27 claimHash) = claimsManager.claims(claimIndex);
-        require(
-            claimHash ==
-                bytes27(
-                    keccak256(
-                        abi.encodePacked(
-                            policyHash,
-                            claimant,
-                            beneficiary,
-                            claimAmountInUsd,
-                            evidence
-                        )
-                    )
-                ),
-            "No such claim"
+    ) external payable override {
+        bytes32 claimHash = keccak256(
+            abi.encodePacked(
+                policyHash,
+                msg.sender,
+                beneficiary,
+                claimAmountInUsd,
+                evidence
+            )
         );
+        uint256 disputeId = claimHashToDisputeId[claimHash];
+        require(disputeId != 0, "Invalid claim");
         // Ruling options
         // 0: Kleros refused to arbitrate or ruled that it's not appropriate to
         // pay out the claim or the settlement. We allow both parties to appeal this.
@@ -133,28 +138,20 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
         // below should revert in that case anyway.
         if (msg.sender == claimant) {
             require(
-                klerosArbitrator.currentRuling(
-                    claimIndexToDisputeId[claimIndex]
-                ) != 1,
+                klerosArbitrator.currentRuling(disputeId) != 1,
                 "Ruling agrees with claimant"
             );
         } else if (claimsManager.isManagerOrMediator(msg.sender)) {
             require(
-                klerosArbitrator.currentRuling(
-                    claimIndexToDisputeId[claimIndex]
-                ) != 2,
+                klerosArbitrator.currentRuling(disputeId) != 2,
                 "Ruling agrees with mediator"
             );
         } else {
             revert("Only parties can appeal");
         }
-        emit AppealedKlerosArbitratorRuling(
-            claimIndex,
-            msg.sender,
-            claimIndexToDisputeId[claimIndex]
-        );
+        emit AppealedKlerosArbitratorRuling(claimHash, msg.sender, disputeId);
         klerosArbitrator.appeal{value: msg.value}(
-            claimIndexToDisputeId[claimIndex],
+            disputeId,
             klerosArbitratorExtraData // Unused in KlerosLiquid
         );
     }
@@ -170,7 +167,6 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
             .ArbitratorDecision(ruling);
         ClaimDetails storage claimDetails = disputeIdToClaimDetails[disputeId];
         claimsManager.resolveDispute(
-            claimDetails.claimIndex,
             claimDetails.policyHash,
             claimDetails.claimant,
             claimDetails.beneficiary,
@@ -180,64 +176,55 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
         );
     }
 
-    function executeRuling(uint256 claimIndex)
-        external
-        override
-        onlyDisputedClaim(claimIndex)
-    {
-        IKlerosLiquid(address(klerosArbitrator)).executeRuling(
-            claimIndexToDisputeId[claimIndex]
-        );
+    function executeRuling(bytes32 claimHash) external override {
+        uint256 disputeId = claimHashToDisputeId[claimHash];
+        require(disputeId != 0, "Invalid claim");
+        IKlerosLiquid(address(klerosArbitrator)).executeRuling(disputeId);
     }
 
     function arbitrationCost() external view override returns (uint256) {
         return klerosArbitrator.arbitrationCost(klerosArbitratorExtraData);
     }
 
-    function appealCost(uint256 claimIndex)
+    function appealCost(bytes32 claimHash)
         external
         view
         override
-        onlyDisputedClaim(claimIndex)
         returns (uint256)
     {
+        uint256 disputeId = claimHashToDisputeId[claimHash];
+        require(disputeId != 0, "Invalid claim");
         return
-            klerosArbitrator.appealCost(
-                claimIndexToDisputeId[claimIndex],
-                klerosArbitratorExtraData
-            );
+            klerosArbitrator.appealCost(disputeId, klerosArbitratorExtraData);
     }
 
-    function disputeStatus(uint256 claimIndex)
+    function disputeStatus(bytes32 claimHash)
         external
         view
         override
-        onlyDisputedClaim(claimIndex)
         returns (IArbitrator.DisputeStatus)
     {
-        return
-            klerosArbitrator.disputeStatus(claimIndexToDisputeId[claimIndex]);
+        uint256 disputeId = claimHashToDisputeId[claimHash];
+        require(disputeId != 0, "Invalid claim");
+        return klerosArbitrator.disputeStatus(disputeId);
     }
 
-    function currentRuling(uint256 claimIndex)
-        external
-        view
-        onlyDisputedClaim(claimIndex)
-        returns (uint256)
-    {
-        return
-            klerosArbitrator.currentRuling(claimIndexToDisputeId[claimIndex]);
+    function currentRuling(bytes32 claimHash) external view returns (uint256) {
+        uint256 disputeId = claimHashToDisputeId[claimHash];
+        require(disputeId != 0, "Invalid claim");
+        return klerosArbitrator.currentRuling(disputeId);
     }
 
-    function appealPeriod(uint256 claimIndex)
+    function appealPeriod(bytes32 claimHash)
         external
         view
         override
-        onlyDisputedClaim(claimIndex)
         returns (uint256 start, uint256 end)
     {
+        uint256 disputeId = claimHashToDisputeId[claimHash];
+        require(disputeId != 0, "Invalid claim");
         (start, end) = IKlerosLiquid(address(klerosArbitrator)).appealPeriod(
-            claimIndexToDisputeId[claimIndex]
+            disputeId
         );
     }
 
@@ -266,11 +253,10 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
         return IKlerosLiquid(address(klerosArbitrator)).courts(subCourtId);
     }
 
-    function claimIndexToDispute(uint256 claimIndex)
+    function claimHashToDispute(bytes32 claimHash)
         external
         view
         override
-        onlyDisputedClaim(claimIndex)
         returns (
             uint96 subCourtId,
             address arbitrated,
@@ -282,9 +268,8 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
             bool ruled
         )
     {
-        return
-            IKlerosLiquid(address(klerosArbitrator)).disputes(
-                claimIndexToDisputeId[claimIndex]
-            );
+        uint256 disputeId = claimHashToDisputeId[claimHash];
+        require(disputeId != 0, "Invalid claim");
+        return IKlerosLiquid(address(klerosArbitrator)).disputes(disputeId);
     }
 }

--- a/contracts/arbitrators/interfaces/IKlerosLiquidProxy.sol
+++ b/contracts/arbitrators/interfaces/IKlerosLiquidProxy.sol
@@ -103,10 +103,17 @@ interface IKlerosLiquidProxy is IEvidence, IArbitrable {
 
     function klerosArbitratorExtraData() external view returns (bytes memory);
 
-    function disputeIdToClaimIndex(uint256 disputeId)
+    function disputeIdToClaimDetails(uint256 disputeId)
         external
         view
-        returns (uint256 claimIndex);
+        returns (
+            uint256 claimIndex,
+            bytes32 policyHash,
+            address claimant,
+            address beneficiary,
+            uint256 amountInUsd,
+            string memory evidence
+        );
 
     function claimIndexToDisputeId(uint256 claimIndex)
         external

--- a/contracts/arbitrators/interfaces/IKlerosLiquidProxy.sol
+++ b/contracts/arbitrators/interfaces/IKlerosLiquidProxy.sol
@@ -8,25 +8,24 @@ import "../../interfaces/IClaimsManager.sol";
 
 interface IKlerosLiquidProxy is IEvidence, IArbitrable {
     event CreatedDispute(
-        uint256 indexed claimIndex,
+        bytes32 indexed claimHash,
         address indexed claimant,
         uint256 indexed disputeId
     );
 
     event SubmittedEvidenceToKlerosArbitrator(
-        uint256 indexed claimIndex,
+        bytes32 indexed claimHash,
         address indexed sender,
         string evidence
     );
 
     event AppealedKlerosArbitratorRuling(
-        uint256 indexed claimIndex,
+        bytes32 indexed claimHash,
         address indexed sender,
         uint256 indexed disputeId
     );
 
     function createDispute(
-        uint256 claimIndex,
         bytes32 policyHash,
         address claimant,
         address beneficiary,
@@ -35,12 +34,11 @@ interface IKlerosLiquidProxy is IEvidence, IArbitrable {
     ) external payable;
 
     function submitEvidenceToKlerosArbitrator(
-        uint256 claimIndex,
+        bytes32 claimHash,
         string calldata evidence
     ) external;
 
     function appealKlerosArbitratorRuling(
-        uint256 claimIndex,
         bytes32 policyHash,
         address claimant,
         address beneficiary,
@@ -48,20 +46,20 @@ interface IKlerosLiquidProxy is IEvidence, IArbitrable {
         string calldata evidence
     ) external payable;
 
-    function executeRuling(uint256 disputeId) external;
+    function executeRuling(bytes32 claimHash) external;
 
     function arbitrationCost() external view returns (uint256);
 
-    function appealCost(uint256 claimIndex) external view returns (uint256);
+    function appealCost(bytes32 claimHash) external view returns (uint256);
 
-    function disputeStatus(uint256 claimIndex)
+    function disputeStatus(bytes32 claimHash)
         external
         view
         returns (IArbitrator.DisputeStatus);
 
-    function currentRuling(uint256 claimIndex) external view returns (uint256);
+    function currentRuling(bytes32 claimHash) external view returns (uint256);
 
-    function appealPeriod(uint256 claimIndex)
+    function appealPeriod(bytes32 claimHash)
         external
         view
         returns (uint256 start, uint256 end);
@@ -83,7 +81,7 @@ interface IKlerosLiquidProxy is IEvidence, IArbitrable {
             uint256 jurorsForCourtJump
         );
 
-    function claimIndexToDispute(uint256 claimIndex)
+    function claimHashToDispute(bytes32 claimHash)
         external
         view
         returns (
@@ -107,7 +105,6 @@ interface IKlerosLiquidProxy is IEvidence, IArbitrable {
         external
         view
         returns (
-            uint256 claimIndex,
             bytes32 policyHash,
             address claimant,
             address beneficiary,
@@ -115,7 +112,7 @@ interface IKlerosLiquidProxy is IEvidence, IArbitrable {
             string memory evidence
         );
 
-    function claimIndexToDisputeId(uint256 claimIndex)
+    function claimHashToDisputeId(bytes32 claimHash)
         external
         view
         returns (uint256 disputeId);

--- a/contracts/arbitrators/interfaces/IKlerosLiquidProxy.sol
+++ b/contracts/arbitrators/interfaces/IKlerosLiquidProxy.sol
@@ -25,14 +25,28 @@ interface IKlerosLiquidProxy is IEvidence, IArbitrable {
         uint256 indexed disputeId
     );
 
-    function createDispute(uint256 claimIndex) external payable;
+    function createDispute(
+        uint256 claimIndex,
+        bytes32 policyHash,
+        address claimant,
+        address beneficiary,
+        uint256 claimAmountInUsd,
+        string calldata evidence
+    ) external payable;
 
     function submitEvidenceToKlerosArbitrator(
         uint256 claimIndex,
         string calldata evidence
     ) external;
 
-    function appealKlerosArbitratorRuling(uint256 claimIndex) external payable;
+    function appealKlerosArbitratorRuling(
+        uint256 claimIndex,
+        bytes32 policyHash,
+        address claimant,
+        address beneficiary,
+        uint256 claimAmountInUsd,
+        string calldata evidence
+    ) external payable;
 
     function executeRuling(uint256 disputeId) external;
 

--- a/contracts/interfaces/IClaimsManager.sol
+++ b/contracts/interfaces/IClaimsManager.sol
@@ -91,15 +91,15 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         uint256 indexed claimIndex,
         address indexed claimant,
         address beneficiary,
-        uint256 clippedAmountInUsd,
-        uint256 clippedAmountInApi3,
+        uint256 clippedPayoutAmountInUsd,
+        uint256 clippedPayoutAmountInApi3,
         address sender
     );
 
     event ProposedSettlement(
         uint256 indexed claimIndex,
         address indexed claimant,
-        uint256 amountInUsd,
+        uint256 settlementAmountInUsd,
         address sender
     );
 
@@ -126,8 +126,8 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         uint256 indexed claimIndex,
         address indexed claimant,
         address beneficiary,
-        uint256 clippedAmountInUsd,
-        uint256 clippedAmountInApi3,
+        uint256 clippedPayoutAmountInUsd,
+        uint256 clippedPayoutAmountInApi3,
         address arbitrator
     );
 
@@ -135,8 +135,8 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         uint256 indexed claimIndex,
         address indexed claimant,
         address beneficiary,
-        uint256 clippedAmountInUsd,
-        uint256 clippedAmountInApi3,
+        uint256 clippedPayoutAmountInUsd,
+        uint256 clippedPayoutAmountInApi3,
         address arbitrator
     );
 
@@ -180,20 +180,52 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         string calldata metadata
     ) external returns (uint256 claimIndex);
 
-    function acceptClaim(uint256 claimIndex) external;
+    function acceptClaim(
+        uint256 claimIndex,
+        bytes32 policyHash,
+        address claimant,
+        address beneficiary,
+        uint256 claimAmountInUsd,
+        string calldata evidence
+    ) external;
 
-    function proposeSettlement(uint256 claimIndex, uint256 amountInUsd)
-        external;
+    function proposeSettlement(
+        uint256 claimIndex,
+        bytes32 policyHash,
+        address claimant,
+        address beneficiary,
+        uint256 claimAmountInUsd,
+        string calldata evidence,
+        uint256 settlementAmountInUsd
+    ) external;
 
-    function acceptSettlement(uint256 claimIndex)
-        external
-        returns (uint256 clippedAmountInApi3);
+    function acceptSettlement(
+        uint256 claimIndex,
+        bytes32 policyHash,
+        address claimant,
+        address beneficiary,
+        uint256 claimAmountInUsd,
+        string calldata evidence
+    ) external returns (uint256 clippedPayoutAmountInApi3);
 
-    function createDispute(uint256 claimIndex) external;
+    function createDispute(
+        uint256 claimIndex,
+        bytes32 policyHash,
+        address claimant,
+        address beneficiary,
+        uint256 claimAmountInUsd,
+        string calldata evidence
+    ) external;
 
-    function resolveDispute(uint256 claimIndex, ArbitratorDecision result)
-        external
-        returns (uint256 clippedAmountInApi3);
+    function resolveDispute(
+        uint256 claimIndex,
+        bytes32 policyHash,
+        address claimant,
+        address beneficiary,
+        uint256 claimAmountInUsd,
+        string calldata evidence,
+        ArbitratorDecision result
+    ) external returns (uint256 clippedAmountInApi3);
 
     function getQuotaUsage(address account) external view returns (uint256);
 
@@ -236,13 +268,9 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         external
         view
         returns (
-            bytes32 policyHash,
             ClaimStatus status,
-            address claimant,
-            address beneficiary,
             uint32 updateTime,
-            uint256 amountInUsd,
-            string memory evidence
+            bytes27 claimHash
         );
 
     function claimIndexToProposedSettlementAmountInUsd(uint256 claimIndex)

--- a/contracts/interfaces/IClaimsManager.sol
+++ b/contracts/interfaces/IClaimsManager.sol
@@ -75,7 +75,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
     );
 
     event CreatedClaim(
-        uint256 indexed claimIndex,
+        bytes32 indexed claimHash,
         address indexed claimant,
         bytes32 indexed policyHash,
         address beneficiary,
@@ -88,7 +88,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
     );
 
     event AcceptedClaim(
-        uint256 indexed claimIndex,
+        bytes32 indexed claimHash,
         address indexed claimant,
         address beneficiary,
         uint256 clippedPayoutAmountInUsd,
@@ -97,33 +97,33 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
     );
 
     event ProposedSettlement(
-        uint256 indexed claimIndex,
+        bytes32 indexed claimHash,
         address indexed claimant,
         uint256 settlementAmountInUsd,
         address sender
     );
 
     event AcceptedSettlement(
-        uint256 indexed claimIndex,
+        bytes32 indexed claimHash,
         address indexed claimant,
         uint256 clippedAmountInUsd,
         uint256 clippedAmountInApi3
     );
 
     event CreatedDispute(
-        uint256 indexed claimIndex,
+        bytes32 indexed claimHash,
         address indexed claimant,
         address arbitrator
     );
 
     event ResolvedDisputeByRejectingClaim(
-        uint256 indexed claimIndex,
+        bytes32 indexed claimHash,
         address indexed claimant,
         address arbitrator
     );
 
     event ResolvedDisputeByAcceptingClaim(
-        uint256 indexed claimIndex,
+        bytes32 indexed claimHash,
         address indexed claimant,
         address beneficiary,
         uint256 clippedPayoutAmountInUsd,
@@ -132,7 +132,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
     );
 
     event ResolvedDisputeByAcceptingSettlement(
-        uint256 indexed claimIndex,
+        bytes32 indexed claimHash,
         address indexed claimant,
         address beneficiary,
         uint256 clippedPayoutAmountInUsd,
@@ -178,10 +178,9 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         uint256 claimAmountInUsd,
         string calldata evidence,
         string calldata metadata
-    ) external returns (uint256 claimIndex);
+    ) external returns (bytes32 claimHash);
 
     function acceptClaim(
-        uint256 claimIndex,
         bytes32 policyHash,
         address claimant,
         address beneficiary,
@@ -190,7 +189,6 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
     ) external;
 
     function proposeSettlement(
-        uint256 claimIndex,
         bytes32 policyHash,
         address claimant,
         address beneficiary,
@@ -200,7 +198,6 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
     ) external;
 
     function acceptSettlement(
-        uint256 claimIndex,
         bytes32 policyHash,
         address claimant,
         address beneficiary,
@@ -209,7 +206,6 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
     ) external returns (uint256 clippedPayoutAmountInApi3);
 
     function createDispute(
-        uint256 claimIndex,
         bytes32 policyHash,
         address claimant,
         address beneficiary,
@@ -218,7 +214,6 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
     ) external;
 
     function resolveDispute(
-        uint256 claimIndex,
         bytes32 policyHash,
         address claimant,
         address beneficiary,
@@ -262,24 +257,13 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         view
         returns (uint32 claimsAllowedUntil, uint224 coverageAmountInUsd);
 
-    function claimCount() external view returns (uint256);
-
-    function claims(uint256 claimIndex)
+    function claimHashToState(bytes32 claimHash)
         external
         view
         returns (
             ClaimStatus status,
             uint32 updateTime,
-            bytes27 claimHash
+            address arbitrator,
+            uint256 proposedSettlementAmountInUsd
         );
-
-    function claimIndexToProposedSettlementAmountInUsd(uint256 claimIndex)
-        external
-        view
-        returns (uint256);
-
-    function claimIndexToArbitrator(uint256 claimIndex)
-        external
-        view
-        returns (address);
 }


### PR DESCRIPTION
Closes https://github.com/api3dao/claims-manager/issues/42, sort of.

This was a bit problematic to implement because the Kleros standard wants to call `KlerosLiquidProxy.rule(disputeId, ruling)`, which will call `ClaimsManager.resolveDispute(claimIndex, policyHash, claimant, beneficiary, claimAmountInUsd, evidence, ruling)`. This means we have to keep the mapping between `disputeId` to claim parameters on-chain. Therefore, I could only postpone storing claim details on-chain until a Kleros dispute is created, and not avoid it completely.

So this PR: 
- Reduces the gas cost of clicking "Create new claim"
- Increases the gas cost of clicking "Escalate to Kleros"
Let me know if you think that the added complexity is worth it.