### PR TITLE
Specify a minimum payout amount in settlement acceptance

### DIFF
--- a/contracts/ClaimsManager.sol
+++ b/contracts/ClaimsManager.sol
@@ -446,7 +446,8 @@ contract ClaimsManager is
         address claimant,
         address beneficiary,
         uint256 claimAmountInUsd,
-        string calldata evidence
+        string calldata evidence,
+        uint256 minimumPayoutAmountInApi3
     ) external returns (uint256 clippedPayoutAmountInApi3) {
         bytes32 claimHash = keccak256(
             abi.encodePacked(
@@ -474,6 +475,10 @@ contract ClaimsManager is
             claimState.proposedSettlementAmountInUsd
         );
         clippedPayoutAmountInApi3 = convertUsdToApi3(clippedPayoutAmountInUsd);
+        require(
+            clippedPayoutAmountInApi3 >= minimumPayoutAmountInApi3,
+            "Payout less than minimum"
+        );
         emit AcceptedSettlement(
             claimHash,
             claimant,

--- a/contracts/interfaces/IClaimsManager.sol
+++ b/contracts/interfaces/IClaimsManager.sol
@@ -202,7 +202,8 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address claimant,
         address beneficiary,
         uint256 claimAmountInUsd,
-        string calldata evidence
+        string calldata evidence,
+        uint256 minimumPayoutAmountInApi3
     ) external returns (uint256 clippedPayoutAmountInApi3);
 
     function createDispute(


### PR DESCRIPTION
Closes https://github.com/api3dao/claims-manager/issues/48

The frontend static-calls `acceptSettlement()` to get `clippedPayoutAmountInApi3`. Then, it can populate `minimumPayoutAmountInApi3` based on a fixed percentage (e.g., 0.95 times `clippedPayoutAmountInApi3`) or a parameterized one (similar to Uniswap). If we decide that we don't want to care about slippage, `minimumPayoutAmountInApi3` just gets set to 0 and everything works as it used to.