### PR TITLE
Use dispute ID instead of claim hash while interacting with the Kleros proxy

### DIFF
--- a/contracts/ClaimsManager.sol
+++ b/contracts/ClaimsManager.sol
@@ -249,7 +249,13 @@ contract ClaimsManager is
         string calldata metadata
     ) external onlyManagerOrPolicyCreator returns (bytes32 policyHash) {
         policyHash = keccak256(
-            abi.encodePacked(claimant, beneficiary, claimsAllowedFrom, policy)
+            abi.encodePacked(
+                claimant,
+                beneficiary,
+                claimsAllowedFrom,
+                policy,
+                metadata
+            )
         );
         PolicyState storage policyState = policyHashToState[policyHash];
         require(policyState.claimsAllowedUntil != 0, "Policy does not exist");

--- a/contracts/arbitrators/KlerosLiquidProxy.sol
+++ b/contracts/arbitrators/KlerosLiquidProxy.sol
@@ -176,9 +176,7 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
         );
     }
 
-    function executeRuling(bytes32 claimHash) external override {
-        uint256 disputeId = claimHashToDisputeId[claimHash];
-        require(disputeId != 0, "Invalid claim");
+    function executeRuling(uint256 disputeId) external override {
         IKlerosLiquid(address(klerosArbitrator)).executeRuling(disputeId);
     }
 
@@ -186,43 +184,35 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
         return klerosArbitrator.arbitrationCost(klerosArbitratorExtraData);
     }
 
-    function appealCost(bytes32 claimHash)
+    function appealCost(uint256 disputeId)
         external
         view
         override
         returns (uint256)
     {
-        uint256 disputeId = claimHashToDisputeId[claimHash];
-        require(disputeId != 0, "Invalid claim");
         return
             klerosArbitrator.appealCost(disputeId, klerosArbitratorExtraData);
     }
 
-    function disputeStatus(bytes32 claimHash)
+    function disputeStatus(uint256 disputeId)
         external
         view
         override
         returns (IArbitrator.DisputeStatus)
     {
-        uint256 disputeId = claimHashToDisputeId[claimHash];
-        require(disputeId != 0, "Invalid claim");
         return klerosArbitrator.disputeStatus(disputeId);
     }
 
-    function currentRuling(bytes32 claimHash) external view returns (uint256) {
-        uint256 disputeId = claimHashToDisputeId[claimHash];
-        require(disputeId != 0, "Invalid claim");
+    function currentRuling(uint256 disputeId) external view returns (uint256) {
         return klerosArbitrator.currentRuling(disputeId);
     }
 
-    function appealPeriod(bytes32 claimHash)
+    function appealPeriod(uint256 disputeId)
         external
         view
         override
         returns (uint256 start, uint256 end)
     {
-        uint256 disputeId = claimHashToDisputeId[claimHash];
-        require(disputeId != 0, "Invalid claim");
         (start, end) = IKlerosLiquid(address(klerosArbitrator)).appealPeriod(
             disputeId
         );

--- a/contracts/arbitrators/KlerosLiquidProxy.sol
+++ b/contracts/arbitrators/KlerosLiquidProxy.sol
@@ -73,13 +73,8 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
         });
         claimHashToDisputeIdPlusOne[claimHash] = disputeId + 1;
         emit CreatedDispute(claimHash, claimant, disputeId);
-        emit Dispute(
-            klerosArbitrator,
-            disputeId,
-            META_EVIDENCE_ID,
-            uint256(claimHash)
-        );
-        emit Evidence(klerosArbitrator, uint256(claimHash), claimant, evidence);
+        emit Dispute(klerosArbitrator, disputeId, META_EVIDENCE_ID, disputeId);
+        emit Evidence(klerosArbitrator, disputeId, claimant, evidence);
         claimsManager.createDispute(
             policyHash,
             claimant,
@@ -90,25 +85,19 @@ contract KlerosLiquidProxy is Multicall, IKlerosLiquidProxy {
     }
 
     function submitEvidenceToKlerosArbitrator(
-        bytes32 claimHash,
+        uint256 disputeId,
         string calldata evidence
     ) external override {
-        require(claimHashToDisputeIdPlusOne[claimHash] != 0, "Invalid claim");
         require(
             claimsManager.isManagerOrMediator(msg.sender),
             "Sender cannot mediate"
         );
         emit SubmittedEvidenceToKlerosArbitrator(
-            claimHash,
+            evidence,
             msg.sender,
-            evidence
+            disputeId
         );
-        emit Evidence(
-            klerosArbitrator,
-            uint256(claimHash),
-            msg.sender,
-            evidence
-        );
+        emit Evidence(klerosArbitrator, disputeId, msg.sender, evidence);
     }
 
     function appealKlerosArbitratorRuling(

--- a/contracts/arbitrators/interfaces/IKlerosLiquidProxy.sol
+++ b/contracts/arbitrators/interfaces/IKlerosLiquidProxy.sol
@@ -14,9 +14,9 @@ interface IKlerosLiquidProxy is IEvidence, IArbitrable {
     );
 
     event SubmittedEvidenceToKlerosArbitrator(
-        bytes32 indexed claimHash,
+        string evidence,
         address indexed sender,
-        string evidence
+        uint256 indexed disputeId
     );
 
     event AppealedKlerosArbitratorRuling(
@@ -34,7 +34,7 @@ interface IKlerosLiquidProxy is IEvidence, IArbitrable {
     ) external payable;
 
     function submitEvidenceToKlerosArbitrator(
-        bytes32 claimHash,
+        uint256 disputeId,
         string calldata evidence
     ) external;
 

--- a/contracts/arbitrators/interfaces/IKlerosLiquidProxy.sol
+++ b/contracts/arbitrators/interfaces/IKlerosLiquidProxy.sol
@@ -46,20 +46,20 @@ interface IKlerosLiquidProxy is IEvidence, IArbitrable {
         string calldata evidence
     ) external payable;
 
-    function executeRuling(bytes32 claimHash) external;
+    function executeRuling(uint256 disputeId) external;
 
     function arbitrationCost() external view returns (uint256);
 
-    function appealCost(bytes32 claimHash) external view returns (uint256);
+    function appealCost(uint256 disputeId) external view returns (uint256);
 
-    function disputeStatus(bytes32 claimHash)
+    function disputeStatus(uint256 disputeId)
         external
         view
         returns (IArbitrator.DisputeStatus);
 
-    function currentRuling(bytes32 claimHash) external view returns (uint256);
+    function currentRuling(uint256 disputeId) external view returns (uint256);
 
-    function appealPeriod(bytes32 claimHash)
+    function appealPeriod(uint256 disputeId)
         external
         view
         returns (uint256 start, uint256 end);

--- a/contracts/arbitrators/interfaces/IKlerosLiquidProxy.sol
+++ b/contracts/arbitrators/interfaces/IKlerosLiquidProxy.sol
@@ -112,8 +112,8 @@ interface IKlerosLiquidProxy is IEvidence, IArbitrable {
             string memory evidence
         );
 
-    function claimHashToDisputeId(bytes32 claimHash)
+    function claimHashToDisputeIdPlusOne(bytes32 claimHash)
         external
         view
-        returns (uint256 disputeId);
+        returns (uint256 disputeIdPlusOne);
 }


### PR DESCRIPTION
Closes https://github.com/api3dao/claims-manager/issues/43 and uses the dispute ID for simpler interactions based on https://github.com/api3dao/claims-manager/issues/43#issuecomment-1216740474