### PR TITLE
Add policy downgrade

### DIFF
--- a/contracts/ClaimsManager.sol
+++ b/contracts/ClaimsManager.sol
@@ -250,7 +250,12 @@ contract ClaimsManager is
         uint256 claimsAllowedUntil,
         string calldata policy,
         string calldata metadata
-    ) external onlyManagerOrPolicyCreator returns (bytes32 policyHash) {
+    )
+        external
+        override
+        onlyManagerOrPolicyCreator
+        returns (bytes32 policyHash)
+    {
         policyHash = keccak256(
             abi.encodePacked(
                 claimant,

--- a/contracts/ClaimsManager.sol
+++ b/contracts/ClaimsManager.sol
@@ -318,6 +318,10 @@ contract ClaimsManager is
             "Increases coverage amount"
         );
         require(
+            claimsAllowedUntil > claimsAllowedFrom,
+            "Start not earlier than end"
+        );
+        require(
             policyState.claimsAllowedUntil >= claimsAllowedUntil,
             "Allows claims for longer"
         );

--- a/contracts/interfaces/IClaimsManager.sol
+++ b/contracts/interfaces/IClaimsManager.sol
@@ -74,6 +74,17 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address sender
     );
 
+    event DowngradedPolicy(
+        address beneficiary,
+        address indexed claimant,
+        bytes32 indexed policyHash,
+        uint256 coverageAmountInUsd,
+        uint256 claimsAllowedFrom,
+        uint256 claimsAllowedUntil,
+        string policy,
+        string metadata
+    );
+
     event CreatedClaim(
         bytes32 indexed claimHash,
         address indexed claimant,
@@ -172,6 +183,16 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
     ) external returns (bytes32 policyHash);
 
     function upgradePolicy(
+        address claimant,
+        address beneficiary,
+        uint256 coverageAmountInUsd,
+        uint256 claimsAllowedFrom,
+        uint256 claimsAllowedUntil,
+        string calldata policy,
+        string calldata metadata
+    ) external returns (bytes32 policyHash);
+
+    function downgradePolicy(
         address claimant,
         address beneficiary,
         uint256 coverageAmountInUsd,

--- a/contracts/interfaces/IClaimsManager.sol
+++ b/contracts/interfaces/IClaimsManager.sol
@@ -171,6 +171,16 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         string calldata metadata
     ) external returns (bytes32 policyHash);
 
+    function upgradePolicy(
+        address claimant,
+        address beneficiary,
+        uint256 coverageAmountInUsd,
+        uint256 claimsAllowedFrom,
+        uint256 claimsAllowedUntil,
+        string calldata policy,
+        string calldata metadata
+    ) external returns (bytes32 policyHash);
+
     function createClaim(
         address beneficiary,
         uint256 claimsAllowedFrom,


### PR DESCRIPTION
Closes https://github.com/api3dao/claims-manager/issues/47

Say a user has 10 days left to be able to make claims and $100k coverage. They want to buy 1 year of $10k coverage. According to https://github.com/api3dao/claims-manager/issues/47#issue-1340509655 they need to wait for 10 days and then buy coverage again, which is not nice.

This PR allows the claimant to downgrade itself to 10 days of $10k coverage, and then buy 1 year of coverage with the same policy hash (which is then doable with `upgradePolicy()`). It feels like this is the best we can do without overengineering PolicyState.