### PR TITLE
Do not allow upgrades that exceed max coverage

### DIFF
--- a/contracts/interfaces/IClaimsManager.sol
+++ b/contracts/interfaces/IClaimsManager.sol
@@ -57,7 +57,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address beneficiary,
         address indexed claimant,
         bytes32 indexed policyHash,
-        uint224 coverageAmountInUsd,
+        uint224 maxCoverageAmountInUsd,
         uint32 claimsAllowedFrom,
         uint32 claimsAllowedUntil,
         string policy,
@@ -68,6 +68,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address beneficiary,
         address indexed claimant,
         bytes32 indexed policyHash,
+        uint224 maxCoverageAmountInUsd,
         uint224 coverageAmountInUsd,
         uint32 claimsAllowedFrom,
         uint32 claimsAllowedUntil,
@@ -79,6 +80,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address beneficiary,
         address indexed claimant,
         bytes32 indexed policyHash,
+        uint224 maxCoverageAmountInUsd,
         uint224 coverageAmountInUsd,
         uint32 claimsAllowedFrom,
         uint32 claimsAllowedUntil,
@@ -98,6 +100,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
         address indexed claimant,
         bytes32 indexed policyHash,
         address beneficiary,
+        uint224 maxCoverageAmountInUsd,
         uint32 claimsAllowedFrom,
         string policy,
         uint224 claimAmountInUsd,
@@ -181,7 +184,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
     function createPolicy(
         address claimant,
         address beneficiary,
-        uint224 coverageAmountInUsd,
+        uint224 maxCoverageAmountInUsd,
         uint32 claimsAllowedFrom,
         uint32 claimsAllowedUntil,
         string calldata policy
@@ -190,6 +193,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
     function upgradePolicy(
         address claimant,
         address beneficiary,
+        uint224 maxCoverageAmountInUsd,
         uint224 coverageAmountInUsd,
         uint32 claimsAllowedFrom,
         uint32 claimsAllowedUntil,
@@ -199,6 +203,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
     function downgradePolicy(
         address claimant,
         address beneficiary,
+        uint224 maxCoverageAmountInUsd,
         uint224 coverageAmountInUsd,
         uint32 claimsAllowedFrom,
         uint32 claimsAllowedUntil,
@@ -208,6 +213,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
     function announcePolicyMetadata(
         address claimant,
         address beneficiary,
+        uint224 maxCoverageAmountInUsd,
         uint32 claimsAllowedFrom,
         string calldata policy,
         string calldata metadata
@@ -215,6 +221,7 @@ interface IClaimsManager is IAccessControlRegistryAdminnedWithManager {
 
     function createClaim(
         address beneficiary,
+        uint224 maxCoverageAmountInUsd,
         uint32 claimsAllowedFrom,
         string calldata policy,
         uint224 claimAmountInUsd,


### PR DESCRIPTION
Related to https://github.com/api3dao/claims-manager/issues/73 and https://github.com/api3dao/claims-manager/issues/78
I will update the tests after this is discussed

New policy purchasing flow:
- User buys an annual policy with a maximum coverage amount.
- They point their dApp to the proxy that refers to this policy hash to signal that the dApp is indeed the owner of the policy. (https://github.com/api3dao/airnode-protocol-v1/blob/oev-sandbox/contracts/dapis/proxies/DapiProxy.sol#L9)
- At any time, anyone can pay to renew the policy to expire 1 year later with the maximum coverage amount. They get a discount proportional to the amount and time left in their current policy (calculated by the Market backend).
- Upgrading requires one to buy an entirely new policy (for which we can require lead time in the form of `claimsAllowedUntil` so https://github.com/api3dao/claims-manager/issues/78 is resolved). There is no discount for the remainder of the old policy. The dApp will need to point to a newly deployed proxy to signal their intention of upgrading.
- Downgrading requires one to buy an entirely new policy (in other words, there is no downgrading and https://github.com/api3dao/claims-manager/issues/73 is irrelevant). There is no discount for the remainder of the old policy. The dApp will need to point to a newly deployed proxy. I kept `downgradePolicy()` to be callable by manager/admin in case of errors in policy creation. I also allowed `claimant` to be able to call it because why not.